### PR TITLE
Fix: simplify sponsors to object array with inline URLs

### DIFF
--- a/src/app/sponsored-by.tsx
+++ b/src/app/sponsored-by.tsx
@@ -4,34 +4,19 @@ import Image from "next/image";
 import { Typography } from "@material-tailwind/react";
 
 const SPONSORS = [
-  "aurasci",
-  "desciindia",
-  "descijapan",
-  "descikolkata",
-  "descilatam",
-  "descilondon",
-  "desciseoul",
-  "descisino",
-  "descitokyo",
-  "desciworld",
-  "gitdataai",
-  "fundesci"
+  { id: "aurasci", url: "https://aurasci.xyz/" },
+  { id: "desciindia", url: "https://desciindia.org/" },
+  { id: "descijapan", url: "https://x.com/DeSciJapan" },
+  { id: "descikolkata", url: "https://x.com/DeSciKolkata" },
+  { id: "descilatam", url: "https://x.com/DeSciLATAM" },
+  { id: "descilondon", url: "https://www.desci.london/" },
+  { id: "desciseoul", url: "https://x.com/DeSciSeoul" },
+  { id: "descisino", url: "https://x.com/DesciSino" },
+  { id: "descitokyo", url: "https://desci-tokyo.jp/" },
+  { id: "desciworld", url: "https://desci.world" },
+  { id: "gitdataai", url: "https://gitdata.ai" },
+  { id: "fundesci", url: "https://fundesci.com/" },
 ];
-
-const SPONSOR_LINKS: { [key: string]: string } = {
-  aurasci: "https://aurasci.xyz/",
-  desciindia: "https://desciindia.org/",
-  descijapan: "https://x.com/DeSciJapan",
-  descikolkata: "https://x.com/DeSciKolkata",
-  descilatam: "https://bento.me/descilatam",
-  descilondon: "https://x.com/DesciLondon",
-  desciseoul: "https://x.com/DesciSeoul",
-  descisino: "https://x.com/DesciSino",
-  descitokyo: "https://desci-tokyo.jp/",
-  desciworld: "https://desci.world/",
-  gitdataai: "https://gitdata.ai/",
-  fundesci: "https://fundesci.com/"
-};
 
 export function SponsoredBy() {
   return (
@@ -41,33 +26,23 @@ export function SponsoredBy() {
           IN COLLABORATION WITH
         </Typography>
         <div className="flex flex-wrap items-center justify-center gap-6">
-          {SPONSORS.map((logo, key) => {
-            const link = SPONSOR_LINKS[logo];
-            const imageElement = (
+          {SPONSORS.map((sponsor) => (
+            <a
+              key={sponsor.id}
+              href={sponsor.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block hover:opacity-80 transition-opacity"
+            >
               <Image
                 width={256}
                 height={256}
-                key={key}
-                src={`/logos/logo-${logo}.jpg`}
-                alt={logo}
+                src={`/logos/logo-${sponsor.id}.jpg`}
+                alt={sponsor.id}
                 className="w-40"
               />
-            );
-
-            return link ? (
-              <a
-                key={key}
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block hover:opacity-80 transition-opacity"
-              >
-                {imageElement}
-              </a>
-            ) : (
-              <div key={key}>{imageElement}</div>
-            );
-          })}
+            </a>
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Replaces separate `SPONSORS` array + `SPONSOR_LINKS` lookup with a single array of `{ id, url }` objects
- Simplifies rendering logic by removing conditional wrapping (all sponsors now have URLs)
- Removes unused `SPONSOR_LINKS` constant and intermediate `imageElement` variable
- Cleaner, more maintainable data structure with 25 fewer lines

## Changes
- `src/app/sponsored-by.tsx`: Refactor sponsor data structure and rendering